### PR TITLE
fix LigMdl a1 using a0 value

### DIFF
--- a/FootGM/LigParms.any
+++ b/FootGM/LigParms.any
@@ -4,6 +4,6 @@
      eps1=.LigParms.eps1;
      L0=.LigParms.L0;
      a0=.LigParms.a0;
-     a1=.LigParms.a0;
+     a1=.LigParms.a1;
    AnyVar Pretension=.LigParms.Pretension;
  };


### PR DESCRIPTION
a1 value in LigParms was pointing to a0. This is fixed. It was pointed in the forum: https://forum.anyscript.org/t/partially-overlapped-segment-issue-in-lower-extremity-model/7294/4